### PR TITLE
Add CanCan to limit post management to admins only.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,6 @@ gem 'sdoc', '~> 0.4.0',          group: :doc
 # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
 gem 'spring',        group: :development
 
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use unicorn as the app server
-# gem 'unicorn'
-
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
@@ -44,3 +38,6 @@ gem 'byebug', group: [:development, :test]
 
 # Use devise for authentication
 gem 'devise'
+
+# Use cancan for authorization
+gem 'cancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
       slop (~> 3.6)
+    cancan (1.6.10)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -137,6 +138,7 @@ DEPENDENCIES
   autoprefixer-rails
   bootstrap-sass (~> 3.3.1)
   byebug
+  cancan
   coffee-rails (~> 4.0.0)
   devise
   haml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Slog
 
-Slog (Shaun's blog) is a Rails app intended to be a learning project.
+Slog (Shaun's blog) is a Rails app intended to be a learning project as
+I make the switch from the .NET realm into the world of Ruby on Rails.
 
-As such, please excuse any ugly code found here.
+As such, please excuse any ugly code found here (though I'm always
+interested in learning more if you have specific constructive criticism).
+
+I'm using Devise (https://github.com/plataformatec/devise) for
+authentication and using Cancan (https://github.com/ryanb/cancan) for
+authorization to limit who can publish blog posts.
+
+Potentially down the road, users who log in will be able to post
+comments, but currently registering/logging in does no good unless they
+are authorized to create/edit posts.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,8 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  rescue_from CanCan::AccessDenied do |exception|
+    redirect_to root_url, alert: exception.message
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,7 @@
 class PostsController < ApplicationController
   before_filter :authenticate_user!, only: [:new, :create, :edit]
+  load_and_authorize_resource
+  skip_authorize_resource only: [:index, :show]
 
   def index
     @posts = Post.all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,12 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    user ||= User.new # guest user (not logged in)
+    if user.admin?
+      can :manage, :all
+    else
+      can :read, :all
+    end
+  end
+end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -5,8 +5,9 @@
 
 = link_to "View all posts", posts_path
 
-%hr
-%h4
-  Admins only! Honor system until authorization implemented.
-  .admin
-    = link_to "Create new post", new_post_path
+- if can? :manage, Post
+  %hr
+  %h4
+    Hello, admin user!
+    .admin
+      = link_to "Create new post", new_post_path

--- a/db/migrate/20150209021917_add_admin_flag_to_user.rb
+++ b/db/migrate/20150209021917_add_admin_flag_to_user.rb
@@ -1,0 +1,9 @@
+class AddAdminFlagToUser < ActiveRecord::Migration
+  def up
+    add_column :users, :admin, :boolean
+  end
+
+  def down
+    remove_column :users, :admin, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150208235105) do
+ActiveRecord::Schema.define(version: 20150209021917) do
 
   create_table "posts", force: true do |t|
     t.string   "title"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20150208235105) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "admin"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
CanCan provides authorization to lock down certain functionality to only admin users (at least for now, more potential uses in the future regarding who can post comments, etc.).